### PR TITLE
Downgrade stunnel due to a bug

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -14,7 +14,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Start-Process -FilePath "C:\Windows\Temp\7z-x64.exe" -ArgumentList /S -NoNewWindow -PassThru -Wait; `
     Remove-Item @('C:\Windows\Temp\*', 'C:\Users\*\Appdata\Local\Temp\*') -Force -Recurse;
 
-ARG STUNNEL_WIN64="https://www.usenix.org.uk/mirrors/stunnel/archive/5.x/stunnel-5.70-win64-installer.exe"
+ARG STUNNEL_WIN64="https://www.usenix.org.uk/mirrors/stunnel/archive/5.x/stunnel-5.69-win64-installer.exe"
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest $env:STUNNEL_WIN64 -OutFile "C:\Windows\Temp\stunnel-win64-installer.exe"; `


### PR DESCRIPTION
- Downgrade stunnel to 5.69 from 5.70.

Windows stunnel 5.70 version info `tstunnel -version` can't be parsed due to a Windows stunnel bug that mangles output.

Prior to this change curl CI jobs that use curl-docker-winbuildenv would not run tests that use the SSL protocol because stunnel version detection would fail.

Ref: https://www.stunnel.org/mailman3/hyperkitty/list/stunnel-users@stunnel.org/thread/SX6LMEZXY7GEAD6ESQV6G2522ME7563X/

Closes #xxxx